### PR TITLE
[FBNB-76 && 21] Review 상태 변경 로직 수정 && bulk update 생성

### DIFF
--- a/src/main/java/com/prgrms/airbnb/domain/reservation/entity/Reservation.java
+++ b/src/main/java/com/prgrms/airbnb/domain/reservation/entity/Reservation.java
@@ -1,18 +1,14 @@
 package com.prgrms.airbnb.domain.reservation.entity;
 
 import com.prgrms.airbnb.domain.common.entity.BaseEntity;
-import java.time.LocalDate;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
-import javax.persistence.Id;
-import javax.persistence.Table;
-import javax.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.util.ObjectUtils;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "reservation")
@@ -20,112 +16,115 @@ import org.springframework.util.ObjectUtils;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Reservation extends BaseEntity {
 
-  @Id
-  @Column(name = "id")
-  private String id;
+    @Id
+    @Column(name = "id")
+    private String id;
 
-  @Enumerated(value = EnumType.STRING)
-  @Column(name = "reservation_status")
-  private ReservationStatus reservationStatus = ReservationStatus.WAITED_OK;
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "reservation_status")
+    private ReservationStatus reservationStatus = ReservationStatus.WAITED_OK;
 
-  @Column(name = "start_date")
-  private LocalDate startDate;
+    @Column(name = "start_date")
+    private LocalDate startDate;
 
-  @Column(name = "end_date")
-  private LocalDate endDate;
+    @Column(name = "end_date")
+    private LocalDate endDate;
 
-  @Column(name = "term")
-  private Integer term;
+    @Column(name = "term")
+    private Integer term;
 
-  @Column(name = "total_price")
-  private Integer totalPrice;
+    @Column(name = "total_price")
+    private Integer totalPrice;
 
-  @NotNull(message = "userId는 null 일 수 없습니다")
-  @Column(name = "user_id")
-  private Long userId;
+    @NotNull(message = "userId는 null 일 수 없습니다")
+    @Column(name = "user_id")
+    private Long userId;
 
-  @NotNull(message = "roomId는 null 일 수 없습니다")
-  @Column(name = "room_id")
-  private Long roomId;
+    @NotNull(message = "roomId는 null 일 수 없습니다")
+    @Column(name = "room_id")
+    private Long roomId;
 
-  public Reservation(String id, ReservationStatus reservationStatus, LocalDate startDate,
-      LocalDate endDate, Integer term, Integer oneDayCharge, Long userId, Long roomId) {
-    setId(id);
-    setReservationStatus(reservationStatus);
-    setStartDate(startDate);
-    setEndDate(endDate);
-    setTerm(term);
-    calculatePrice(oneDayCharge);
-    setUserId(userId);
-    setRoomId(roomId);
-  }
-
-  public void changeStatus(ReservationStatus newReservationStatus) {
-    reservationStatus = reservationStatus.changeStatus(newReservationStatus);
-  }
-
-  public boolean canReviewed(){
-    return reservationStatus.equals(ReservationStatus.WAIT_REVIEW);
-  }
-
-  public boolean canCancelled() {
-    if (startDate.isAfter(LocalDate.now()) || startDate.isEqual(LocalDate.now())) {
-      //TODO: 환불 정책 필요, 에러 추가 필요
-      throw new IllegalArgumentException();
+    public Reservation(String id, ReservationStatus reservationStatus, LocalDate startDate,
+                       LocalDate endDate, Integer term, Integer oneDayCharge, Long userId, Long roomId) {
+        setId(id);
+        setReservationStatus(reservationStatus);
+        setStartDate(startDate);
+        setEndDate(endDate);
+        setTerm(term);
+        calculatePrice(oneDayCharge);
+        setUserId(userId);
+        setRoomId(roomId);
     }
-    return this.reservationStatus.equals(ReservationStatus.WAITED_OK)
-        || this.reservationStatus.equals(ReservationStatus.ACCEPTED);
-  }
 
-  private void setId(String id) {
-    if (ObjectUtils.isEmpty(id)) {
-      throw new IllegalArgumentException();
+    public void changeStatus(ReservationStatus newReservationStatus) {
+        reservationStatus = reservationStatus.changeStatus(newReservationStatus);
     }
-    this.id = id;
-  }
 
-  private void setReservationStatus(ReservationStatus reservationStatus) {
-    if (ObjectUtils.isEmpty(reservationStatus)) {
-      throw new IllegalArgumentException();
+    public boolean canReviewed() {
+        if (endDate.plusDays(14).isBefore(LocalDate.now())) {
+            return false;
+        }
+        return reservationStatus.equals(ReservationStatus.WAIT_REVIEW);
     }
-  }
 
-  private void setStartDate(LocalDate checkIn) {
-    if (ObjectUtils.isEmpty(checkIn)) {
-      throw new IllegalArgumentException();
+    public boolean canCancelled() {
+        if (startDate.isAfter(LocalDate.now()) || startDate.isEqual(LocalDate.now())) {
+            //TODO: 환불 정책 필요, 에러 추가 필요
+            throw new IllegalArgumentException();
+        }
+        return this.reservationStatus.equals(ReservationStatus.WAITED_OK)
+                || this.reservationStatus.equals(ReservationStatus.ACCEPTED);
     }
-    this.startDate = checkIn;
-  }
 
-  private void setEndDate(LocalDate checkOut) {
-    if (ObjectUtils.isEmpty(checkOut)) {
-      throw new IllegalArgumentException();
+    private void setId(String id) {
+        if (ObjectUtils.isEmpty(id)) {
+            throw new IllegalArgumentException();
+        }
+        this.id = id;
     }
-    this.endDate = checkOut;
-  }
 
-  private void setTerm(Integer period) {
-    if (ObjectUtils.isEmpty(period)) {
-      throw new IllegalArgumentException();
+    private void setReservationStatus(ReservationStatus reservationStatus) {
+        if (ObjectUtils.isEmpty(reservationStatus)) {
+            throw new IllegalArgumentException();
+        }
     }
-    this.term = period;
-  }
 
-  private void setUserId(Long userId) {
-    if (ObjectUtils.isEmpty(userId)) {
-      throw new IllegalArgumentException();
+    private void setStartDate(LocalDate checkIn) {
+        if (ObjectUtils.isEmpty(checkIn)) {
+            throw new IllegalArgumentException();
+        }
+        this.startDate = checkIn;
     }
-    this.userId = userId;
-  }
 
-  private void setRoomId(Long roomId) {
-    if (ObjectUtils.isEmpty(roomId)) {
-      throw new IllegalArgumentException();
+    private void setEndDate(LocalDate checkOut) {
+        if (ObjectUtils.isEmpty(checkOut)) {
+            throw new IllegalArgumentException();
+        }
+        this.endDate = checkOut;
     }
-    this.roomId = roomId;
-  }
 
-  private void calculatePrice(Integer charge) {
-    totalPrice = charge * term;
-  }
+    private void setTerm(Integer period) {
+        if (ObjectUtils.isEmpty(period)) {
+            throw new IllegalArgumentException();
+        }
+        this.term = period;
+    }
+
+    private void setUserId(Long userId) {
+        if (ObjectUtils.isEmpty(userId)) {
+            throw new IllegalArgumentException();
+        }
+        this.userId = userId;
+    }
+
+    private void setRoomId(Long roomId) {
+        if (ObjectUtils.isEmpty(roomId)) {
+            throw new IllegalArgumentException();
+        }
+        this.roomId = roomId;
+    }
+
+    private void calculatePrice(Integer charge) {
+        totalPrice = charge * term;
+    }
 }

--- a/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationRepository.java
@@ -9,7 +9,7 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.ThreadLocalRandom;
 
-public interface ReservationRepository extends JpaRepository<Reservation, String> {
+public interface ReservationRepository extends JpaRepository<Reservation, String>, ReservationStatusRepository {
 
     Slice<Reservation> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
 

--- a/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationStatusRepository.java
+++ b/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationStatusRepository.java
@@ -1,4 +1,5 @@
 package com.prgrms.airbnb.domain.reservation.repository;
 
 public interface ReservationStatusRepository {
+    void updateReservationStatus();
 }

--- a/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationStatusRepository.java
+++ b/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationStatusRepository.java
@@ -1,0 +1,4 @@
+package com.prgrms.airbnb.domain.reservation.repository;
+
+public interface ReservationStatusRepository {
+}

--- a/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationStatusRepositoryImpl.java
+++ b/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationStatusRepositoryImpl.java
@@ -1,4 +1,31 @@
 package com.prgrms.airbnb.domain.reservation.repository;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import javax.persistence.EntityManager;
+import java.time.LocalDate;
+
+import static com.prgrms.airbnb.domain.reservation.entity.QReservation.reservation;
+import static com.prgrms.airbnb.domain.reservation.entity.ReservationStatus.*;
+
 public class ReservationStatusRepositoryImpl implements ReservationStatusRepository {
+    private JPAQueryFactory jpaQueryFactory;
+
+    public ReservationStatusRepositoryImpl(EntityManager em) {
+        this.jpaQueryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public void updateReservationStatus() {
+        //이용 후 다음 날부터 리뷰를 남길 수 있다.
+        jpaQueryFactory.update(reservation)
+                .set(reservation.reservationStatus, WAIT_REVIEW)
+                .where(reservation.endDate.after(LocalDate.now()), reservation.reservationStatus.eq(ACCEPTED))
+                .execute();
+        //리뷰는 14일 이내에 남길 수 있다.
+        jpaQueryFactory.update(reservation)
+                .set(reservation.reservationStatus, COMPLETE)
+                .where(reservation.endDate.after(LocalDate.now().minusDays(14)), reservation.reservationStatus.eq(WAIT_REVIEW))
+                .execute();
+    }
 }

--- a/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationStatusRepositoryImpl.java
+++ b/src/main/java/com/prgrms/airbnb/domain/reservation/repository/ReservationStatusRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.prgrms.airbnb.domain.reservation.repository;
+
+public class ReservationStatusRepositoryImpl implements ReservationStatusRepository {
+}

--- a/src/main/java/com/prgrms/airbnb/domain/review/entity/Review.java
+++ b/src/main/java/com/prgrms/airbnb/domain/review/entity/Review.java
@@ -45,6 +45,15 @@ public class Review extends BaseEntity {
         setImages(images);
     }
 
+    public Review(Long id, String comment, Integer rating, String reservationId, Boolean visible, List<ReviewImage> images) {
+        this.id = id;
+        setComment(comment);
+        setRating(rating);
+        setReservationId(reservationId);
+        setVisible(visible);
+        setImages(images);
+    }
+
     public Boolean isVisible() {
         return visible;
     }

--- a/src/main/java/com/prgrms/airbnb/domain/review/service/ReviewService.java
+++ b/src/main/java/com/prgrms/airbnb/domain/review/service/ReviewService.java
@@ -34,7 +34,6 @@ public class ReviewService {
 
     @Transactional
     public ReviewResponse save(String reservationId, CreateReviewRequest createReviewRequest) {
-        //TODO: 리턴 타입 지정해야함
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(IllegalArgumentException::new);
         if (!reservation.canReviewed()) {
@@ -48,7 +47,6 @@ public class ReviewService {
 
     @Transactional
     public ReviewResponse modify(Long reviewId, UpdateReviewRequest updateReviewRequest) {
-        //TODO: 리턴 타입 지정해야함
         Review review = reviewRepository.findById(reviewId).orElseThrow(IllegalArgumentException::new);
         review.changeComment(updateReviewRequest.getComment());
         review.changeRating(updateReviewRequest.getRating());

--- a/src/main/java/com/prgrms/airbnb/domain/review/service/ReviewService.java
+++ b/src/main/java/com/prgrms/airbnb/domain/review/service/ReviewService.java
@@ -1,6 +1,7 @@
 package com.prgrms.airbnb.domain.review.service;
 
 import com.prgrms.airbnb.domain.reservation.entity.Reservation;
+import com.prgrms.airbnb.domain.reservation.entity.ReservationStatus;
 import com.prgrms.airbnb.domain.reservation.repository.ReservationRepository;
 import com.prgrms.airbnb.domain.review.dto.CreateReviewRequest;
 import com.prgrms.airbnb.domain.review.dto.ReviewResponse;
@@ -41,6 +42,7 @@ public class ReviewService {
         }
         Review review = ReviewConverter.toReview(reservationId, createReviewRequest);
         Review savedReview = reviewRepository.save(review);
+        reservation.changeStatus(ReservationStatus.COMPLETE);
         return ReviewConverter.of(savedReview);
     }
 

--- a/src/main/resources/sql/schema_new.sql
+++ b/src/main/resources/sql/schema_new.sql
@@ -93,3 +93,26 @@ create table reservation
     user_id            bigint       not null,
     primary key (id)
 );
+
+create table review
+(
+    id            bigint NOT NULL AUTO_INCREMENT,
+    created_at    timestamp,
+    updated_at    timestamp,
+    comment       varchar(255),
+    rating        integer,
+    visible       boolean,
+    reservation_id  varchar(255) not null,
+    primary key (id)
+);
+
+create table review_image
+(
+    id         bigint NOT NULL AUTO_INCREMENT,
+    created_at timestamp,
+    updated_at timestamp,
+    path       varchar(255),
+    review_id    bigint not null,
+    primary key (id),
+    CONSTRAINT fk_review_id_for_review_image FOREIGN KEY (review_id) REFERENCES review (id) ON DELETE RESTRICT ON UPDATE RESTRICT
+);

--- a/src/test/java/com/prgrms/airbnb/domain/review/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/prgrms/airbnb/domain/review/repository/ReviewRepositoryTest.java
@@ -1,0 +1,36 @@
+package com.prgrms.airbnb.domain.review.repository;
+
+import com.prgrms.airbnb.domain.reservation.repository.ReservationRepository;
+import com.prgrms.airbnb.domain.review.entity.Review;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class ReviewRepositoryTest {
+
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Test
+    @DisplayName("review 객체 생성: 빈 이미지인 경우")
+    void empty_image_save() {
+        Review review = new Review(
+                "여기 좋아용",
+                5,
+                "245325",
+                true,
+                null
+        );
+        reviewRepository.save(review);
+        Assertions.assertThat(review.getId()).isNotNull();
+    }
+}


### PR DESCRIPTION
## 업무 배경
> 업무 이유, 목적, 이슈 등 업무의 배경을 간단하게 1줄 요약 합니다.
- 리뷰 조회 시 권한 체크를 해야 하고 기간에 따라 review 상태가 변경이 가능해야 함
## TO BE
> 수정 or 추가, 개발 될 내용에 대해서 1줄로 간단히 작성합니다.
- 리뷰 조회할때 익명 글이면서 현재 로그인된 user의 id와 reservation의 userId가 다를땐 List에 보이지 않도록 했습니다.
- 리뷰 작성이 되면 reservation의 상태가 바뀌도록 수정했습니다. 
- reservationStatus가 wait_review에서 completed로 바뀌는 경우는 2가지입니다. 1. 리뷰 작성 후 2. 2주가 지난 경우
- 2주가 지난 경우는 @scheduled를 통해 매일 새벽 5시에 bulk update를 돌리는 방향으로 설정했습니다. (bulk update는 query Dsl에서 수행해야 스프링의 더티체킹 기능을 사용하지 않아 성능 상 이점이 있다고 합니다.)
- bulk update를 돌리는 경우는 윗 줄의 내용과 승인된 예약에 한 해서 이용 기간(endDate)가 끝나면 리뷰 상태로 넘어가도록 생각했습니다. endDate 다음 날이 퇴실 날이고 LocalDate 객체라서 문제 없어보입니다.
- 테스트 코드는 계속해서 작성 중이에용
## Link
- Jira: [FBNB-76](https://dhkstnaos.atlassian.net/browse/FBNB-76?atlOrigin=eyJpIjoiZDdhNzhjNTBmM2UyNDE4ZWE2Njk0ODBmYzI1ZjkwMjUiLCJwIjoiaiJ9)